### PR TITLE
Honor max_attempts in util::retry.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn move_update(
 
 		let max_attempts = match entry_file_type.is_file() {
 			true => None,
-			false => Some(26), // wait longer if folder
+			false => Some(27), // wait longer if folder
 		};
 
 		// attempt to delete

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,12 +9,12 @@ use std::{thread, time};
  * Quadratic backoff retry mechanism.
  *
  * Use `max_attempts` to control how long it should retry for:
- * 	- 10 (default): 19s
- *  - 15: ~1 minute
- *  - 19: ~2 minutes
- *  - 22: ~3 minutes
- *  - 24: ~4 minutes
- *  - 26: ~5 minutes
+ * 	- 11 (default): 19s
+ *  - 16: ~1 minute
+ *  - 20: ~2 minutes
+ *  - 23: ~3 minutes
+ *  - 25: ~4 minutes
+ *  - 27: ~5 minutes
  */
 pub fn retry<F, R, E, T>(closure: F, max_attempts: T) -> Result<R, E>
 where
@@ -22,7 +22,7 @@ where
 	T: Into<Option<u32>>,
 {
 	let mut attempt: u32 = 0;
-	let max_attempts = max_attempts.into().unwrap_or(10);
+	let max_attempts = max_attempts.into().unwrap_or(11);
 
 	loop {
 		attempt += 1;
@@ -31,7 +31,7 @@ where
 		match result {
 			Ok(_) => return result,
 			Err(_) => {
-				if attempt > max_attempts {
+				if attempt >= max_attempts {
 					return result;
 				}
 


### PR DESCRIPTION
Original check for ``attempt > max_attempts`` actually causes one more attempt than specified:

e.g. for a case with max_attempt = 2...
```
attempt #1 fails
sleep #1
attempt #2 fails
sleep #2 
attempt #3 fails
<conditional triggers exit> 
```

The correction does:
```
attempt #1 fails
sleep #1
attempt #2 fails
<conditional triggers exit>
```

Since callers seem more interested in max time interval, I updated the default, the callers, and the function doc accordingly.

An alternative solution would be keeping the old code and renaming `max_attempts` to `max_sleeps` since that's what it is actually bounding.