### PR TITLE
Fix some trivial clippy warnings

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -109,6 +109,7 @@ pub fn run_progress_window(silent: bool, tx: Sender<ProgressWindow>) {
 	}
 }
 
+#[derive(Copy, Clone)]
 pub enum MessageBoxType {
 	Error,
 	RetryCancel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use std::time::SystemTime;
 use std::vec::Vec;
 use std::{env, error, fmt, fs, io, thread};
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn read_file(path: &Path) -> Result<(Header, Vec<FileRec>), Box<error::Error>> {
 	let input_file = fs::File::open(path)?;
@@ -96,14 +96,14 @@ fn delete_existing_version(
 	let root = PathBuf::from(root_path);
 	directories.push_back(root);
 
-	while directories.len() > 0 {
+	while !directories.is_empty() {
 		let dir = directories.pop_front().unwrap();
 		info!(log, "Reading directory: {:?}", dir);
 
 		for entry in fs::read_dir(&dir)? {
 			let entry = entry?;
 			let entry_name = entry.file_name();
-			let entry_name = entry_name.to_str().ok_or(io::Error::new(
+			let entry_name = entry_name.to_str().ok_or_else(|| io::Error::new(
 				io::ErrorKind::Other,
 				"could not get entry name",
 			))?;
@@ -211,7 +211,7 @@ fn move_update(
 		"move_update: {:?}, {}", uninstdat_path, update_folder_name
 	);
 
-	let root_path = uninstdat_path.parent().ok_or(io::Error::new(
+	let root_path = uninstdat_path.parent().ok_or_else(|| io::Error::new(
 		io::ErrorKind::Other,
 		"could not get parent path of uninstdat",
 	))?;
@@ -232,7 +232,7 @@ fn move_update(
 	for entry in fs::read_dir(&update_path)? {
 		let entry = entry?;
 		let entry_name = entry.file_name();
-		let entry_name = entry_name.to_str().ok_or(io::Error::new(
+		let entry_name = entry_name.to_str().ok_or_else(|| io::Error::new(
 			io::ErrorKind::Other,
 			"Could not get entry name",
 		))?;
@@ -268,7 +268,7 @@ fn patch_uninstdat(
 	info!(log, "header: {:?}", header);
 	info!(log, "num_recs: {:?}", recs.len());
 
-	let root_path = uninstdat_path.parent().ok_or(io::Error::new(
+	let root_path = uninstdat_path.parent().ok_or_else(|| io::Error::new(
 		io::ErrorKind::Other,
 		"could not get parent path of uninstdat",
 	))?;
@@ -299,7 +299,7 @@ fn do_update(
 ) -> Result<(), Box<error::Error>> {
 	info!(log, "do_update: {:?}, {}", code_path, update_folder_name);
 
-	let root_path = code_path.parent().ok_or(io::Error::new(
+	let root_path = code_path.parent().ok_or_else(|| io::Error::new(
 		io::ErrorKind::Other,
 		"could not get parent path of uninstdat",
 	))?;
@@ -365,7 +365,7 @@ impl error::Error for ArgumentError {
 	}
 }
 
-fn _main(log: &slog::Logger, args: &Vec<String>) -> Result<(), Box<error::Error>> {
+fn _main(log: &slog::Logger, args: &[String]) -> Result<(), Box<error::Error>> {
 	info!(log, "Starting: {}, {}", args[1], args[2]);
 
 	let code_path = PathBuf::from(&args[1]);
@@ -406,7 +406,7 @@ fn handle_error(log_path: &str) {
 	gui::message_box(&msg, "VS Code", gui::MessageBoxType::Error);
 }
 
-fn __main(args: &Vec<String>) -> i32 {
+fn __main(args: &[String]) -> i32 {
 	let mut log_path = env::temp_dir();
 	log_path.push(format!(
 		"vscode-inno-updater-{:?}.log",
@@ -507,7 +507,7 @@ fn main() {
 			Some(5),
 		);
 
-		if let Err(_) = result {
+		if result.is_err() {
 			handle_error(&log_path);
 		}
 

--- a/src/model/filerec.rs
+++ b/src/model/filerec.rs
@@ -255,7 +255,7 @@ impl<'a> FileRec {
 			.map_err(|_| FileRecParseError("Failed to parse file rec data size"))?
 			as usize;
 
-		if data_size > 0x8000000 {
+		if data_size > 0x0800_0000 {
 			return Err(FileRecParseError("File rec data size too large"));
 		}
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -70,7 +70,7 @@ pub fn get_running_processes() -> Result<Vec<RunningProcess>, io::Error> {
 			}
 		}
 
-		return Ok(result);
+		Ok(result)
 	}
 }
 
@@ -101,7 +101,7 @@ fn kill_process_if(
 			process.id,
 		);
 
-		if handle == ptr::null_mut() {
+		if handle.is_null() {
 			return Err(io::Error::new(
 				io::ErrorKind::Other,
 				format!(
@@ -158,12 +158,12 @@ fn kill_process_if(
 }
 
 pub fn wait_or_kill(log: &slog::Logger, path: &Path) -> Result<(), Box<error::Error>> {
-	let file_name = path.file_name().ok_or(io::Error::new(
+	let file_name = path.file_name().ok_or_else(|| io::Error::new(
 		io::ErrorKind::Other,
 		"could not get process file name",
 	))?;
 
-	let file_name = file_name.to_str().ok_or(io::Error::new(
+	let file_name = file_name.to_str().ok_or_else(|| io::Error::new(
 		io::ErrorKind::Other,
 		"could not get convert file name to str",
 	))?;
@@ -184,13 +184,13 @@ pub fn wait_or_kill(log: &slog::Logger, path: &Path) -> Result<(), Box<error::Er
 			.filter(|p| p.name == file_name)
 			.collect();
 
-		if processes.len() == 0 {
+		if processes.is_empty() {
 			info!(log, "{} is not running", file_name);
 			break;
 		}
 
 		// give up after 60 * 500ms = 30 seconds
-		if attempt == 60 || processes.len() == 0 {
+		if attempt == 60 || processes.is_empty() {
 			info!(log, "Gave up waiting for {} to exit", file_name);
 			break;
 		}

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -20,17 +20,17 @@ pub fn read_utf8_string(reader: &mut Read, capacity: usize) -> Result<String, Re
 
 	reader
 		.read_exact(&mut vec)
-		.map_err(|err| ReadUtf8StringError::IOError(err))
+		.map_err(ReadUtf8StringError::IOError)
 		.and_then(|_| {
 			let pos = vec.iter().position(|&x| x == 0).unwrap_or(64);
 			let bar = &vec[0..pos];
-			String::from_utf8(Vec::from(bar)).map_err(|err| ReadUtf8StringError::UTF8Error(err))
+			String::from_utf8(Vec::from(bar)).map_err(ReadUtf8StringError::UTF8Error)
 		})
 }
 
 pub fn write_utf8_string(
 	writer: &mut Write,
-	string: &String,
+	string: &str,
 	capacity: usize,
 ) -> Result<(), io::Error> {
 	let bytes = string.as_bytes();
@@ -52,7 +52,7 @@ pub fn from_utf16(value: &[u16]) -> Result<String, io::Error> {
 	use std::ffi::OsString;
 	use std::os::windows::ffi::OsStringExt;
 
-	let pos = value.iter().position(|&x| x == 0).unwrap_or(value.len());
+	let pos = value.iter().position(|&x| x == 0).unwrap_or_else(|| value.len());
 	let value = &value[0..pos];
 
 	OsString::from_wide(value)

--- a/src/util.rs
+++ b/src/util.rs
@@ -48,7 +48,7 @@ where
 					}
 				}
 
-				thread::sleep(time::Duration::from_millis((attempt.pow(2) * 50) as u64));
+				thread::sleep(time::Duration::from_millis(u64::from(attempt.pow(2) * 50)));
 			}
 		}
 	}


### PR DESCRIPTION
I didn't see any way to test the soundness of the changes, but I believe most of these changes are fairly trivial in nature. 

There were a couple of warnings that I wasn't sure of because of the lack of tests, and decided to leave those out. Specifically a couple of double reference clones [here](https://github.com/Microsoft/inno-updater/blob/134071c5da24e60de27c24a79a031573c45ca76d/src/model/filerec.rs#L98) and [here](https://github.com/Microsoft/inno-updater/blob/134071c5da24e60de27c24a79a031573c45ca76d/src/model/filerec.rs#L101) (see [Clippy#clone_double_ref](https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#clone_double_ref)).

Most of the changes were related to [Clippy#or_fun_call](https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#or_fun_call).