### PR TITLE
Remove an unnecessary String conversion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,13 +114,13 @@ fn delete_existing_version(
 					continue;
 				}
 
-				// don't delete any of the unins* files
-				if String::from(entry_name).starts_with("unins") {
-					continue;
-				}
-
 				// don't delete ourselves
 				if entry_name == "tools" {
+					continue;
+				}
+				
+				// don't delete any of the unins* files
+				if entry_name.starts_with("unins") {
 					continue;
 				}
 			}


### PR DESCRIPTION
Unless I'm mistaken, the `String::from` call is redundant, as `starts_with` operates on the existing slice. Might've just been a leftover from something prior.