### PR TITLE
Increase control width to avoid truncating text

### DIFF
--- a/resources/resources.rc
+++ b/resources/resources.rc
@@ -11,7 +11,7 @@ STYLE 72 | 80 | 512 | 4 | 2147483648 | 12582912
 CAPTION "Visual Studio Code"
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Updating Visual Studio Code...",-1,11,10,66,8
+    LTEXT           "Updating Visual Studio Code...",-1,11,10,165,8
     // 8 == PBS_MARQUEE
     // 8388608 == WS_BORDER
     CONTROL         "",10001,"msctls_progress32",8 | 8388608,11,27,165,14


### PR DESCRIPTION
The text change in 887301db0f14d20f7a39cb6645f955bf32ac9a6d from `"Updating VS Code..."` to `"Updating Visual Studio Code..."` made it wide enough to be truncated and only show "Updating Visual".

This PR gives the text control the same width as the progress bar. It should fix https://github.com/microsoft/vscode/issues/81433 .

I have only tested it in a resource editor, and not by actually building and running the updater.