### PR TITLE
feat: replace unmaintained winapi with windows-sys

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+hard_tabs = true
+
+# Requires nightly
+# imports_granularity = "Module"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -329,3 +329,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,42 +347,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,20 @@ slog = "2.1.1"
 slog-async = "2.2.0"
 slog-term = "2.3.0"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "^0.3.9", features = ["winuser", "libloaderapi", "commctrl", "processthreadsapi", "tlhelp32", "handleapi", "psapi", "errhandlingapi", "winbase", "shellapi"] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.42"
+features = [
+    "Win32_Foundation",
+    "Win32_System_Shutdown",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Threading",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Diagnostics_ToolHelp"
+]
 
 [profile.release]
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,12 @@ fn main() {
 
 	assert!(ecode.success(), "Resource compiler failed");
 
-	println!("cargo:rustc-link-search=native={}", resources.parent().unwrap().to_str().unwrap());
-	println!("cargo:rustc-link-lib={}", resources.file_stem().unwrap().to_str().unwrap());
+	println!(
+		"cargo:rustc-link-search=native={}",
+		resources.parent().unwrap().to_str().unwrap()
+	);
+	println!(
+		"cargo:rustc-link-lib={}",
+		resources.file_stem().unwrap().to_str().unwrap()
+	);
 }

--- a/src/blockio.rs
+++ b/src/blockio.rs
@@ -5,9 +5,8 @@
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crc::{crc32, Hasher32};
-use std::cmp;
-use std::io;
 use std::io::prelude::*;
+use std::{cmp, io};
 
 const BLOCK_MAX_SIZE: usize = 4096;
 
@@ -48,8 +47,8 @@ impl<'a> BlockRead<'a> {
 		}
 
 		let size = size as usize;
-		let mut buffer = &mut self.buffer[..size];
-		self.reader.read_exact(&mut buffer)?;
+		let buffer = &mut self.buffer[..size];
+		self.reader.read_exact(buffer)?;
 
 		let mut digest = crc32::Digest::new(crc32::IEEE);
 		digest.write(buffer);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -29,13 +29,17 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: u32, _: WPARAM, l: LPARAM) ->
 	};
 
 	match msg {
-		v if v == WM_INITDIALOG => {
+		WM_INITDIALOG => {
 			let data = &*(l as *const DialogData);
 			if !data.silent {
 				SendDlgItemMessageW(hwnd, resources::PROGRESS_SLIDER, WM_USER + 10, 1, 0);
 
-				#[allow(clippy::uninit_assumed_init)]
-				let mut rect = mem::MaybeUninit::<RECT>::uninit().assume_init();
+				let mut rect = RECT {
+					top: 0,
+					left: 0,
+					bottom: 0,
+					right: 0,
+				};
 				GetWindowRect(hwnd, &mut rect);
 
 				let width = rect.right - rect.left;
@@ -65,7 +69,7 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: u32, _: WPARAM, l: LPARAM) ->
 			ShutdownBlockReasonCreate(hwnd, to_utf16("Visual Studio Code is updating...").as_ptr());
 			0
 		}
-		v if v == WM_DESTROY => {
+		WM_DESTROY => {
 			ShutdownBlockReasonDestroy(hwnd);
 			0
 		}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -6,13 +6,11 @@
 use std::sync::mpsc::Sender;
 use std::{mem, ptr};
 use strings::to_utf16;
-use winapi::shared::basetsd::INT_PTR;
-use winapi::shared::minwindef::{BOOL, DWORD, LPARAM, UINT, WPARAM};
-use winapi::shared::ntdef::LPCWSTR;
-use winapi::shared::windef::HWND;
+use windows_sys::core::PCWSTR;
+use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, WPARAM};
 
 extern "system" {
-	pub fn ShutdownBlockReasonCreate(hWnd: HWND, pwszReason: LPCWSTR) -> BOOL;
+	pub fn ShutdownBlockReasonCreate(hWnd: HWND, pwszReason: PCWSTR) -> BOOL;
 	pub fn ShutdownBlockReasonDestroy(hWnd: HWND) -> BOOL;
 }
 
@@ -21,22 +19,22 @@ struct DialogData {
 	tx: Sender<ProgressWindow>,
 }
 
-unsafe extern "system" fn dlgproc(hwnd: HWND, msg: UINT, _: WPARAM, l: LPARAM) -> INT_PTR {
+unsafe extern "system" fn dlgproc(hwnd: HWND, msg: u32, _: WPARAM, l: LPARAM) -> isize {
 	use resources;
-	use winapi::shared::windef::RECT;
-	use winapi::um::commctrl::PBM_SETMARQUEE;
-	use winapi::um::processthreadsapi::GetCurrentThreadId;
-	use winapi::um::winuser::{
-		GetDesktopWindow, GetWindowRect, SendDlgItemMessageW, SetWindowPos, ShowWindow, HWND_TOPMOST,
-		SW_HIDE, WM_DESTROY, WM_INITDIALOG,
+	use windows_sys::Win32::Foundation::RECT;
+	use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+	use windows_sys::Win32::UI::WindowsAndMessaging::{
+		GetDesktopWindow, GetWindowRect, SendDlgItemMessageW, SetWindowPos, ShowWindow,
+		HWND_TOPMOST, SW_HIDE, WM_DESTROY, WM_INITDIALOG, WM_USER,
 	};
 
 	match msg {
-		WM_INITDIALOG => {
+		v if v == WM_INITDIALOG => {
 			let data = &*(l as *const DialogData);
 			if !data.silent {
-				SendDlgItemMessageW(hwnd, resources::PROGRESS_SLIDER, PBM_SETMARQUEE, 1, 0);
+				SendDlgItemMessageW(hwnd, resources::PROGRESS_SLIDER, WM_USER + 10, 1, 0);
 
+				#[allow(clippy::uninit_assumed_init)]
 				let mut rect = mem::MaybeUninit::<RECT>::uninit().assume_init();
 				GetWindowRect(hwnd, &mut rect);
 
@@ -58,8 +56,7 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: UINT, _: WPARAM, l: LPARAM) -
 				ShowWindow(hwnd, SW_HIDE);
 			}
 
-			data
-				.tx
+			data.tx
 				.send(ProgressWindow {
 					ui_thread_id: GetCurrentThreadId(),
 				})
@@ -68,7 +65,7 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: UINT, _: WPARAM, l: LPARAM) -
 			ShutdownBlockReasonCreate(hwnd, to_utf16("Visual Studio Code is updating...").as_ptr());
 			0
 		}
-		WM_DESTROY => {
+		v if v == WM_DESTROY => {
 			ShutdownBlockReasonDestroy(hwnd);
 			0
 		}
@@ -77,14 +74,14 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: UINT, _: WPARAM, l: LPARAM) -
 }
 
 pub struct ProgressWindow {
-	ui_thread_id: DWORD,
+	ui_thread_id: u32,
 }
 
 unsafe impl Send for ProgressWindow {}
 
 impl ProgressWindow {
 	pub fn exit(&self) {
-		use winapi::um::winuser::{PostThreadMessageW, WM_QUIT};
+		use windows_sys::Win32::UI::WindowsAndMessaging::{PostThreadMessageW, WM_QUIT};
 
 		unsafe {
 			PostThreadMessageW(self.ui_thread_id, WM_QUIT, 0, 0);
@@ -94,16 +91,16 @@ impl ProgressWindow {
 
 pub fn run_progress_window(silent: bool, tx: Sender<ProgressWindow>) {
 	use resources;
-	use winapi::um::libloaderapi::GetModuleHandleW;
-	use winapi::um::winuser::{DialogBoxParamW, MAKEINTRESOURCEW};
+	use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+	use windows_sys::Win32::UI::WindowsAndMessaging::DialogBoxParamW;
 
 	let data = DialogData { silent, tx };
 
 	unsafe {
 		DialogBoxParamW(
 			GetModuleHandleW(ptr::null_mut()),
-			MAKEINTRESOURCEW(resources::PROGRESS_DIALOG),
-			ptr::null_mut(),
+			resources::PROGRESS_DIALOG as PCWSTR,
+			mem::zeroed(),
 			Some(dlgproc),
 			(&data as *const DialogData) as LPARAM,
 		);
@@ -130,16 +127,16 @@ pub enum MessageBoxResult {
 }
 
 pub fn message_box(text: &str, caption: &str, mbtype: MessageBoxType) -> MessageBoxResult {
-	use winapi::um::winuser::{
-		MessageBoxW, IDABORT, IDCANCEL, IDCONTINUE, IDIGNORE, IDNO, IDOK, IDRETRY, IDTRYAGAIN, IDYES,
-		MB_ICONERROR, MB_RETRYCANCEL, MB_SYSTEMMODAL,
+	use windows_sys::Win32::UI::WindowsAndMessaging::{
+		MessageBoxW, IDABORT, IDCANCEL, IDCONTINUE, IDIGNORE, IDNO, IDOK, IDRETRY, IDTRYAGAIN,
+		IDYES, MB_ICONERROR, MB_RETRYCANCEL, MB_SYSTEMMODAL,
 	};
 
 	let result: i32;
 
 	unsafe {
 		result = MessageBoxW(
-			ptr::null_mut(),
+			mem::zeroed(),
 			to_utf16(text).as_ptr(),
 			to_utf16(caption).as_ptr(),
 			match mbtype {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -3,96 +3,97 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *----------------------------------------------------------------------------------------*/
 
+use std::ffi::c_void;
 use std::path::Path;
 use std::{error, io, ptr};
 use strings::to_u16s;
 use util;
-use winapi::um::winnt::HANDLE;
+use windows_sys::Win32::Foundation::HANDLE;
 
 pub struct FileHandle(HANDLE);
 
 impl FileHandle {
-    pub fn new(path: &Path) -> Result<FileHandle, Box<dyn error::Error>> {
-        use winapi::um::fileapi::CreateFileW;
-        use winapi::um::fileapi::OPEN_EXISTING;
-        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-        use winapi::um::winnt::DELETE;
-        use winapi::um::winnt::FILE_ATTRIBUTE_NORMAL;
+	pub fn new(path: &Path) -> Result<FileHandle, Box<dyn error::Error>> {
+		use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+		use windows_sys::Win32::Storage::FileSystem::{
+			CreateFileW, DELETE, FILE_ATTRIBUTE_NORMAL, OPEN_EXISTING,
+		};
 
-        unsafe {
-            let handle = CreateFileW(
-                to_u16s(path.as_os_str()).as_ptr(),
-                DELETE,
-                0,
-                ptr::null_mut(),
-                OPEN_EXISTING,
-                FILE_ATTRIBUTE_NORMAL,
-                ptr::null_mut(),
-            );
+		unsafe {
+			let handle = CreateFileW(
+				to_u16s(path.as_os_str()).as_ptr(),
+				DELETE,
+				0,
+				ptr::null_mut(),
+				OPEN_EXISTING,
+				FILE_ATTRIBUTE_NORMAL,
+				std::mem::zeroed(),
+			);
 
-            if handle == INVALID_HANDLE_VALUE {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "Failed to create file handle: {}",
-                        util::get_last_error_message()?
-                    ),
-                )
-                .into());
-            }
+			if handle == INVALID_HANDLE_VALUE {
+				return Err(io::Error::new(
+					io::ErrorKind::Other,
+					format!(
+						"Failed to create file handle: {}",
+						util::get_last_error_message()?
+					),
+				)
+				.into());
+			}
 
-            Ok(FileHandle(handle))
-        }
-    }
+			Ok(FileHandle(handle))
+		}
+	}
 
-    pub fn mark_for_deletion(&self) -> Result<(), Box<dyn error::Error>> {
-        use std::mem;
-        use winapi::shared::minwindef::{DWORD, FALSE, LPVOID, TRUE};
-        use winapi::um::fileapi::SetFileInformationByHandle;
-        use winapi::um::fileapi::FILE_DISPOSITION_INFO;
-        use winapi::um::minwinbase::FileDispositionInfo;
+	pub fn mark_for_deletion(&self) -> Result<(), Box<dyn error::Error>> {
+		use std::mem;
+		use windows_sys::Win32::Foundation::BOOLEAN;
+		use windows_sys::Win32::Storage::FileSystem::{
+			FileDispositionInfo, SetFileInformationByHandle, FILE_DISPOSITION_INFO,
+		};
 
-        unsafe {
-            let mut info = FILE_DISPOSITION_INFO { DeleteFile: TRUE as u8 };
-            let result = SetFileInformationByHandle(
-                self.0,
-                FileDispositionInfo,
-                &mut info as *mut _ as LPVOID,
-                mem::size_of::<FILE_DISPOSITION_INFO>() as DWORD,
-            );
+		unsafe {
+			let mut info = FILE_DISPOSITION_INFO {
+				DeleteFile: 1 as BOOLEAN,
+			};
+			let result = SetFileInformationByHandle(
+				self.0,
+				FileDispositionInfo,
+				&mut info as *mut _ as *mut c_void,
+				mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+			);
 
-            if result == FALSE {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "Failed to mark file for deletion: {}",
-                        util::get_last_error_message()?
-                    ),
-                )
-                .into());
-            }
-        }
+			if result.is_negative() {
+				return Err(io::Error::new(
+					io::ErrorKind::Other,
+					format!(
+						"Failed to mark file for deletion: {}",
+						util::get_last_error_message()?
+					),
+				)
+				.into());
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    pub fn close(&self) -> Result<(), Box<dyn error::Error>> {
-        use winapi::shared::minwindef::FALSE;
-        use winapi::um::handleapi::CloseHandle;
+	pub fn close(&self) -> Result<(), Box<dyn error::Error>> {
+		use windows_sys::Win32::Foundation::CloseHandle;
 
-        unsafe {
-            if CloseHandle(self.0) == FALSE {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "Failed to close file handle: {}",
-                        util::get_last_error_message()?
-                    ),
-                )
-                .into());
-            }
-        }
+		unsafe {
+			if CloseHandle(self.0).is_negative() {
+				return Err(io::Error::new(
+					io::ErrorKind::Other,
+					format!(
+						"Failed to close file handle: {}",
+						util::get_last_error_message()?
+					),
+				)
+				.into());
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,8 +100,7 @@ fn delete_existing_version(
 	let root = PathBuf::from(root_path);
 	directories.push_back(root);
 
-	while directories.is_empty() {
-		let dir = directories.pop_front().unwrap();
+	while let Some(dir) = directories.pop_front() {
 		info!(log, "Reading directory: {:?}", dir);
 
 		for entry in fs::read_dir(&dir)? {
@@ -412,9 +411,9 @@ fn _main(log: &slog::Logger, args: &[String]) -> Result<(), Box<dyn error::Error
 
 fn handle_error(log_path: &str) {
 	let msg = format!(
-		"Failed to install Visual Studio Code update.
-		Updates may fail due to anti-virus software and/or runaway processes. Please try restarting your machine before attempting to update again.
-		Please read the log file for more information:
+		"Failed to install Visual Studio Code update.\n\n\
+		Updates may fail due to anti-virus software and/or runaway processes. Please try restarting your machine before attempting to update again.\n\n\
+		Please read the log file for more information:\n\n\
 		{log_path}"
 	);
 

--- a/src/model/header.rs
+++ b/src/model/header.rs
@@ -112,8 +112,7 @@ impl Header {
 			.map_err(|_| HeaderParseError("Failed to parse header flags"))?;
 
 		let mut reserved = [0; 108];
-		read
-			.read_exact(&mut reserved)
+		read.read_exact(&mut reserved)
 			.map_err(|_| HeaderParseError("Failed to parse header reserved"))?;
 
 		let crc = read

--- a/src/process.rs
+++ b/src/process.rs
@@ -46,7 +46,7 @@ pub fn get_running_processes() -> Result<Vec<RunningProcess>, io::Error> {
 
 		pe32.dwSize = mem::size_of::<PROCESSENTRY32W>() as u32;
 
-		if Process32FirstW(handle, &mut pe32).is_negative() {
+		if Process32FirstW(handle, &mut pe32) == 0 {
 			CloseHandle(handle);
 
 			return Err(io::Error::new(
@@ -66,7 +66,7 @@ pub fn get_running_processes() -> Result<Vec<RunningProcess>, io::Error> {
 				id: pe32.th32ProcessID,
 			});
 
-			if Process32NextW(handle, &mut pe32).is_negative() {
+			if Process32NextW(handle, &mut pe32) == 0 {
 				CloseHandle(handle);
 				break;
 			}

--- a/src/process.rs
+++ b/src/process.rs
@@ -84,7 +84,7 @@ fn kill_process_if(
 	process: &RunningProcess,
 	path: &Path,
 ) -> Result<(), Box<dyn error::Error>> {
-	use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, MAX_PATH};
+	use windows_sys::Win32::Foundation::{CloseHandle, MAX_PATH};
 	use windows_sys::Win32::System::ProcessStatus::K32GetModuleFileNameExW;
 	use windows_sys::Win32::System::Threading::{
 		OpenProcess, TerminateProcess, PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE,
@@ -98,7 +98,7 @@ fn kill_process_if(
 
 	unsafe {
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms684320(v=vs.85).aspx
-		let handle: HANDLE = OpenProcess(
+		let handle = OpenProcess(
 			PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_TERMINATE,
 			0,
 			process.id,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -4,10 +4,9 @@
  *----------------------------------------------------------------------------------------*/
 
 use std::ffi::OsStr;
-use std::io;
 use std::io::prelude::*;
 use std::os::windows::ffi::OsStrExt;
-use std::string;
+use std::{io, string};
 
 #[derive(Debug)]
 pub enum ReadUtf8StringError {
@@ -23,11 +22,11 @@ pub fn read_utf8_string(
 
 	reader
 		.read_exact(&mut vec)
-		.map_err(|err| ReadUtf8StringError::IOError(err))
+		.map_err(ReadUtf8StringError::IOError)
 		.and_then(|_| {
 			let pos = vec.iter().position(|&x| x == 0).unwrap_or(64);
 			let bar = &vec[0..pos];
-			String::from_utf8(Vec::from(bar)).map_err(|err| ReadUtf8StringError::UTF8Error(err))
+			String::from_utf8(Vec::from(bar)).map_err(ReadUtf8StringError::UTF8Error)
 		})
 }
 
@@ -37,7 +36,7 @@ pub fn write_utf8_string(
 	capacity: usize,
 ) -> Result<(), io::Error> {
 	let bytes = string.as_bytes();
-	writer.write_all(&bytes)?;
+	writer.write_all(bytes)?;
 
 	let rest = vec![0; capacity - bytes.len()];
 	writer.write_all(&rest)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,8 +35,11 @@ where
 			Err(err) => {
 				if attempt >= max_attempts {
 					let msg = format!("There was an error while {}:\n\n{}\n\nPlease verify there are no Visual Studio Code processes still executing.", task, err);
-					let mb_result =
-						gui::message_box(&msg, "Visual Studio Code", gui::MessageBoxType::RetryCancel);
+					let mb_result = gui::message_box(
+						&msg,
+						"Visual Studio Code",
+						gui::MessageBoxType::RetryCancel,
+					);
 
 					match mb_result {
 						gui::MessageBoxResult::Retry => {
@@ -55,8 +58,8 @@ where
 }
 
 pub fn get_last_error_message() -> Result<String, Box<dyn error::Error>> {
-	use winapi::um::errhandlingapi::GetLastError;
-	use winapi::um::winbase::{
+	use windows_sys::Win32::Foundation::GetLastError;
+	use windows_sys::Win32::System::Diagnostics::Debug::{
 		FormatMessageW, FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS,
 	};
 


### PR DESCRIPTION
winapi has been unmaintained for a long time
this commit replaces winapi with windows-sys which is generated from windows API headers and maintained by Microsoft
apart from that, codebase has been fixed from few clippy lints and errors

winapi is still an indirect dependency via:
- [ ] [atty](https://github.com/softprops/atty) | https://github.com/softprops/atty/pull/54
- [ ] [term](https://github.com/Stebalien/term)
- [ ] [dir-sys-next](https://github.com/xdg-rs/dirs) | https://github.com/xdg-rs/dirs/pull/62
