### PR TITLE
ignore process permission denied

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -84,7 +84,7 @@ fn kill_process_if(
 	process: &RunningProcess,
 	path: &Path,
 ) -> Result<(), Box<dyn error::Error>> {
-	use windows_sys::Win32::Foundation::{CloseHandle, MAX_PATH};
+	use windows_sys::Win32::Foundation::{CloseHandle, MAX_PATH, ERROR_ACCESS_DENIED, GetLastError};
 	use windows_sys::Win32::System::ProcessStatus::K32GetModuleFileNameExW;
 	use windows_sys::Win32::System::Threading::{
 		OpenProcess, TerminateProcess, PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE,
@@ -104,16 +104,26 @@ fn kill_process_if(
 			process.id,
 		);
 
-		if ptr::eq(handle as *mut c_void, ptr::null()) {
-			return Err(io::Error::new(
-				io::ErrorKind::Other,
-				format!(
-					"Failed to open process: {}",
-					util::get_last_error_message()?
-				),
-			)
-			.into());
-		}
+	        if ptr::eq(handle as *mut c_void, ptr::null_mut()) {
+	            let error_code = GetLastError();
+	
+	            // Check for insufficient permission
+	            if error_code == ERROR_ACCESS_DENIED {
+	                info!(
+	                    log,
+	                    "Insufficient permissions to open process: {}", process.id
+	                );
+	                return Ok(()); // Ignore the error and return Ok
+	            } else {
+	                return Err(io::Error::new(
+	                    io::ErrorKind::Other,
+	                    format!(
+	                        "Failed to open process: {}",
+	                        util::get_last_error_message()?
+	                    ),
+	                ).into());
+	            }
+	        }
 
 		let mut raw_path = [0u16; MAX_PATH as usize];
 		let len = K32GetModuleFileNameExW(handle, mem::zeroed(), raw_path.as_mut_ptr(), MAX_PATH)


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/76641

This ignores the error from OpenProcess() if it is access denied.

Provided the error value and GetLastError() call are correct and imported correctly.

If you can get the process information you can't terminate the process.

Hopefully this fixes the you can't upgrade a user installed vs code if other users are running vs code on a multi user system.