### PR TITLE
fix: dialog is show when silent is true

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -25,8 +25,8 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: u32, _: WPARAM, l: LPARAM) ->
 	use windows_sys::Win32::Foundation::RECT;
 	use windows_sys::Win32::System::Threading::GetCurrentThreadId;
 	use windows_sys::Win32::UI::WindowsAndMessaging::{
-		GetDesktopWindow, GetWindowRect, SendDlgItemMessageW, SetDlgItemTextW, SetWindowPos,
-		ShowWindow, HWND_TOPMOST, SW_HIDE, WM_DESTROY, WM_INITDIALOG, WM_USER,
+		EndDialog, GetDesktopWindow, GetWindowRect, SendDlgItemMessageW, SetDlgItemTextW,
+		SetWindowPos, HWND_TOPMOST, SW_HIDE, WM_DESTROY, WM_INITDIALOG, WM_USER,
 	};
 
 	match msg {
@@ -62,7 +62,7 @@ unsafe extern "system" fn dlgproc(hwnd: HWND, msg: u32, _: WPARAM, l: LPARAM) ->
 					0,
 				);
 			} else {
-				ShowWindow(hwnd, SW_HIDE);
+				EndDialog(hwnd, 0);
 			}
 
 			data.tx


### PR DESCRIPTION
`ShowWindow(hwdn, SW_HIDE)` does not work for the dialog (DialogBoxParamW); to achieve silence, it can only be implemented through `EndDialog`.

Since VSCode is relatively small in size, the dialog disappears quickly (around 200ms) during the upgrade process, so if you don't pay close attention, it goes unnoticed.

Reproduce video(at 6 seconds):

https://github.com/user-attachments/assets/7adc4bc7-243c-4c37-93b2-05d3b132672a

If you want to replicate it locally, you can replace the line https://github.com/microsoft/inno-updater/blob/2732251c088fae3c1f3e32acfa5200b3e21bd6fc/src/main.rs#L358 with: `thread::sleep(std::time::Duration::from_millis(2000));`, and then execute:

```shell
cargo run -- C:/Users/USERNAME/AppData/Local/Programs/Microsoft\ VS\ Code/Code.exe true "test"
```