### PR TITLE
v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "inno_updater"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inno_updater"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Microsoft <monacotools@microsoft.com>"]
 build = "build.rs"
 


### PR DESCRIPTION
There are no code changes in this repository between v0.14.0 and v0.14.1, but we have updated the release pipeline to use a newer version of Rust and some more compiler flags. 