### PR TITLE
fix: cargo warning in `decode_strings`

### DIFF
--- a/src/model/filerec.rs
+++ b/src/model/filerec.rs
@@ -95,11 +95,10 @@ impl<'a> error::Error for StringDecodeError<'a> {
 
 fn decode_strings<'a>(data: &[u8]) -> Result<Vec<String>, StringDecodeError<'a>> {
 	let mut result: Vec<String> = Vec::with_capacity(10);
-	let mut slice = data.clone();
+	let mut slice = data;
 
 	loop {
-		let reader: &mut dyn Read = &mut slice.clone();
-		let byte_result = reader
+		let byte_result = slice
 			.read_u8()
 			.map_err(|_| StringDecodeError("Failed to parse file rec string header"))?;
 
@@ -107,7 +106,7 @@ fn decode_strings<'a>(data: &[u8]) -> Result<Vec<String>, StringDecodeError<'a>>
 			0x00..=0xfc => panic!("What 0x{:x}", byte_result),
 			0xfd => panic!("What 0x{:x}", byte_result),
 			0xfe => {
-				let size = reader
+				let size = slice
 					.read_i32::<LittleEndian>()
 					.map_err(|_| StringDecodeError("Failed to parse file rec string size"))?;
 
@@ -117,17 +116,16 @@ fn decode_strings<'a>(data: &[u8]) -> Result<Vec<String>, StringDecodeError<'a>>
 					assert_eq!(size % 2, 0);
 
 					let mut u16data: Vec<u16> = vec![0; size / 2];
-					LittleEndian::read_u16_into(&slice[5..5 + size], &mut u16data);
+					slice.read_u16_into::<LittleEndian>(&mut u16data)
+						.map_err(|_| StringDecodeError("Rec data string was too short"))?;
 
 					let string = String::from_utf16(&u16data)
 						.map_err(|_| StringDecodeError("Failed to parse file rec data string"))?;
 					result.push(string);
 				}
-
-				slice = &slice[5 + size..];
 			}
 			0xff => {
-				if slice.len() != 1 {
+				if slice.len() != 0 {
 					return Err(StringDecodeError("Invalid file rec string header length"));
 				}
 				return Ok(result);
@@ -317,5 +315,67 @@ impl FileRec {
 			extra_data: self.extra_data,
 			data: encode_strings(&rebased_paths)?,
 		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_decode_strings() {
+		// Empty list (just the end marker 0xFF)
+		let empty_data = [0xFF];
+		let result = decode_strings(&empty_data).unwrap();
+		assert_eq!(result.len(), 0);
+
+		// One string "Hello"
+		// -10 in little-endian i32 = [0xF6, 0xFF, 0xFF, 0xFF]
+		let one_string = [
+			0xFE, 0xF6, 0xFF, 0xFF, 0xFF, // header + size (-10)
+			b'H', 0, b'e', 0, b'l', 0, b'l', 0, b'o', 0, // "Hello" in UTF-16LE
+			0xFF, // end marker
+		];
+		let result = decode_strings(&one_string).unwrap();
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0], "Hello");
+
+		// Multiple strings ("Hello", "Hi")
+		let multi_string = [
+			0xFE, 0xF6, 0xFF, 0xFF, 0xFF, // header + size (-10)
+			b'H', 0, b'e', 0, b'l', 0, b'l', 0, b'o', 0, // "Hello" in UTF-16LE
+			0xFE, 0xFC, 0xFF, 0xFF, 0xFF, // header + size (-4)
+			b'H', 0, b'i', 0, // "Hi" in UTF-16LE
+			0xFF, // end marker
+		];
+		let result = decode_strings(&multi_string).unwrap();
+		assert_eq!(result.len(), 2);
+		assert_eq!(result[0], "Hello");
+		assert_eq!(result[1], "Hi");
+
+		// Empty string (size = 0, should not be added)
+		let zero_length = [
+			0xFE, 0x00, 0x00, 0x00, 0x00, // header + size (0)
+			0xFF, // end marker
+		];
+		let result = decode_strings(&zero_length).unwrap();
+		assert_eq!(result.len(), 0);
+
+		// Error - Invalid end marker (extra data)
+		let invalid_end = [
+			0xFE, 0xF6, 0xFF, 0xFF, 0xFF, // header + size (-10)
+			b'H', 0, b'e', 0, b'l', 0, b'l', 0, b'o', 0, // "Hello" in UTF-16LE
+			0xFF, 0x00, // invalid end - extra byte
+		];
+		let result = decode_strings(&invalid_end);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	#[should_panic(expected = "What 0xfc")]
+	fn test_decode_strings_panic_on_invalid_header() {
+		// This should panic because the header is invalid
+		let invalid_header = [0xFC];
+		let _ = decode_strings(&invalid_header);
 	}
 }


### PR DESCRIPTION
Previously what the function was doing was a little esoteric keeping and
updating two different references to `data`. This resulted in a compile
warning that `cargo clippy` incorrectly fixed.

This PR normalizes a bit to avoid the two references and use only read
methods on the slice. Also includes unit tests which pass on main and
this branch.

cc @joaomoreno can you validate this works irl?