### PR TITLE
fix: add retry logic to rename step to handle locked executables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -671,13 +671,24 @@ fn perform_three_way_rename(
 	// Step 1: If new file exists and current file exists, rename current to old
 	if new_path.exists() && current_path.exists() {
 		info!(log, "Renaming current to old: {:?} -> {:?}", current_path, old_path);
-		if let Err(err) = fs::rename(current_path, old_path) {
-			error!(log, "Failed to rename current to old: {}", err);
-			return Err(Box::new(io::Error::new(
-				io::ErrorKind::Other,
-				format!("Failed to rename current to old: {}", err),
-			)));
-		}
+		// Use retry logic to handle OS error 32 (file locked by another process).
+		// Child processes or lingering handles may temporarily hold a lock on the
+		// executable, so we retry with quadratic backoff to give them time to release.
+		util::retry(
+			&format!("renaming {:?} to {:?}", current_path, old_path),
+			|attempt| {
+				info!(log, "Attempting rename: {:?} -> {:?} (attempt {})", current_path, old_path, attempt);
+				fs::rename(current_path, old_path).map_err(|err| {
+					error!(log, "Failed to rename current to old: {} (attempt {})", err, attempt);
+					let boxed: Box<dyn error::Error> = Box::new(io::Error::new(
+						io::ErrorKind::Other,
+						format!("Failed to rename current to old: {}", err),
+					));
+					boxed
+				})
+			},
+			None,
+		)?;
 	} else if !new_path.exists() {
 		// No new file to rename, so nothing to do
 		return Ok(());


### PR DESCRIPTION
## Summary

- Wraps the \"current → old\" rename in \`perform_three_way_rename\` with the existing \`util::retry\` mechanism (quadratic backoff, ~19s across 11 attempts)
- Fixes the update failure when lingering child processes hold a file lock on \`Code.exe\`, causing OS error 32 (\"The process cannot access the file because it is being used by another process\")
- Uses the same retry pattern already established in \`handle.rs\` and \`process.rs\`

## Context

When VS Code triggers a background update, the Inno updater renames \`Code.exe → old_Code.exe\` before replacing it with the new version. If child processes (extensions, terminals, etc.) still have a handle on \`Code.exe\`, this rename fails immediately with no retry, showing the user a generic \"Failed to install Visual Studio Code update\" dialog.

The fix reuses the existing \`util::retry\` helper which retries with quadratic backoff (\`attempt² × 50ms\`) up to 11 times (~19s total), then shows a Retry/Cancel dialog — consistent with how other file operations in the updater already handle contention.

## Test plan

- [ ] \`cargo check --target i686-pc-windows-msvc\` passes

Fixes microsoft/vscode#308524