### PR TITLE
fix: avoid replacing occupied old files during update 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "inno_updater"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "byteorder",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inno_updater"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Microsoft <monacotools@microsoft.com>"]
 edition = "2024"
 build = "build.rs"

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -32,15 +32,7 @@ impl FileHandle {
 			);
 
 			if handle == INVALID_HANDLE_VALUE {
-				return Err(io::Error::new(
-					io::ErrorKind::Other,
-					format!(
-						"Failed to create file handle: {}\nPath: \"{}\"",
-						util::get_last_error_message()?,
-						path.display()
-					),
-				)
-				.into());
+				return Err(io::Error::last_os_error().into());
 			}
 
 			Ok(FileHandle(handle))

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,15 +668,44 @@ fn perform_three_way_rename(
 	old_path: &Path,
 	new_path: &Path,
 ) -> Result<(), Box<dyn error::Error>> {
+	let requested_old_path = old_path;
+	let old_path = find_available_old_path(requested_old_path)?;
+	if old_path != requested_old_path {
+		warn!(
+			log,
+			"Old destination already exists; using alternate path to avoid replacing a potentially running executable: requested={:?}, alternate={:?}",
+			requested_old_path,
+			old_path
+		);
+	}
+
 	// Step 1: If new file exists and current file exists, rename current to old
 	if new_path.exists() && current_path.exists() {
-		info!(log, "Renaming current to old: {:?} -> {:?}", current_path, old_path);
-		if let Err(err) = fs::rename(current_path, old_path) {
-			error!(log, "Failed to rename current to old: {}", err);
+		info!(log, "Renaming current to old: {:?} -> {:?}", current_path, &old_path);
+		if let Err(err) = fs::rename(current_path, &old_path) {
+			error!(
+				log,
+				"Failed to rename current executable to an available destination: error={}, os_error={:?}, current_exists={}, selected_old_exists={}, requested_old_exists={}, current={:?}, selected_old={:?}, requested_old={:?}",
+				err,
+				err.raw_os_error(),
+				current_path.exists(),
+				old_path.exists(),
+				requested_old_path.exists(),
+				current_path,
+				old_path,
+				requested_old_path
+			);
 			return Err(Box::new(io::Error::new(
 				io::ErrorKind::Other,
 				format!("Failed to rename current to old: {}", err),
 			)));
+		}
+		if old_path != requested_old_path {
+			info!(
+				log,
+				"Successfully renamed current executable using alternate old path; the source is renameable while the requested destination remains occupied: {:?}",
+				requested_old_path
+			);
 		}
 	} else if !new_path.exists() {
 		// No new file to rename, so nothing to do
@@ -691,7 +720,7 @@ fn perform_three_way_rename(
 		// Restore old file if the operation fails and old file exists
 		if old_path.exists() {
 			info!(log, "Restoring old file: {:?} -> {:?}", old_path, current_path);
-			if let Err(restore_err) = fs::rename(old_path, current_path) {
+			if let Err(restore_err) = fs::rename(&old_path, current_path) {
 				error!(log, "Failed to restore old file: {}", restore_err);
 			}
 		}
@@ -703,6 +732,33 @@ fn perform_three_way_rename(
 	}
 
 	Ok(())
+}
+
+fn find_available_old_path(old_path: &Path) -> Result<PathBuf, Box<dyn error::Error>> {
+	if !old_path.exists() {
+		return Ok(old_path.to_owned());
+	}
+
+	let parent = old_path.parent().ok_or_else(|| {
+		io::Error::new(
+			io::ErrorKind::Other,
+			"Could not get parent directory of old path",
+		)
+	})?;
+	let file_name = old_path
+		.file_name()
+		.and_then(|name| name.to_str())
+		.ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Could not get old file name"))?;
+	let base_name = file_name.strip_prefix("old_").unwrap_or(file_name);
+
+	for suffix in 1.. {
+		let candidate = parent.join(format!("old_{}_{}", suffix, base_name));
+		if !candidate.exists() {
+			return Ok(candidate);
+		}
+	}
+
+	unreachable!()
 }
 
 fn cleanup_dll_files(
@@ -1060,6 +1116,27 @@ mod tests {
         let old_content = fs::read_to_string(&old_path).unwrap();
         assert_eq!(current_content, "new content", "Current file should contain new content");
         assert_eq!(old_content, "current content", "Old file should contain original content");
+    }
+
+    #[test]
+    fn test_perform_three_way_rename_preserves_existing_old_file() {
+        let temp_dir = tempdir().unwrap();
+        let log = setup_test_logger();
+        let current_path = temp_dir.path().join("current.txt");
+        let old_path = temp_dir.path().join("old_current.txt");
+        let new_path = temp_dir.path().join("new_current.txt");
+        let available_old_path = temp_dir.path().join("old_1_current.txt");
+
+        fs::write(&current_path, "current content").unwrap();
+        fs::write(&old_path, "previous old content").unwrap();
+        fs::write(&new_path, "new content").unwrap();
+
+        let result = perform_three_way_rename(&log, &current_path, &old_path, &new_path);
+
+        assert!(result.is_ok(), "Rename operation should succeed");
+        assert_eq!(fs::read_to_string(&current_path).unwrap(), "new content");
+        assert_eq!(fs::read_to_string(&old_path).unwrap(), "previous old content");
+        assert_eq!(fs::read_to_string(&available_old_path).unwrap(), "current content");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -856,6 +856,33 @@ fn is_skippable_lock_error(err: &io::Error) -> bool {
 	)
 }
 
+fn open_file_for_gc(
+	log: &slog::Logger,
+	path: &Path,
+) -> Result<Option<FileHandle>, Box<dyn error::Error>> {
+	match FileHandle::new(path) {
+		Ok(file_handle) => Ok(Some(file_handle)),
+		Err(err) => {
+			let skippable = err
+				.downcast_ref::<io::Error>()
+				.map(is_skippable_lock_error)
+				.unwrap_or(false);
+			if skippable {
+				warn!(
+					log,
+					"Skipping locked file during gc, will retry on next update: {:?}: {}",
+					path,
+					err
+				);
+				Ok(None)
+			} else {
+				error!(log, "Failed to open file for gc: {:?}: {}", path, err);
+				Err(err)
+			}
+		}
+	}
+}
+
 fn remove_files(
 	log: &slog::Logger,
 	code_path: &Path,
@@ -960,22 +987,10 @@ fn remove_files(
 					if bin_entry_file_type.is_file() {
 						if bin_entry_name.starts_with("old_") {
 							info!(log, "Will delete old file in bin: {:?}", bin_entry_path);
-							
-							let msg = format!("Opening file handle: {:?}", bin_entry_path);
-							let file_handle = util::retry(
-								&msg,
-								|attempt| -> Result<FileHandle, Box<dyn error::Error>> {
-									info!(
-										log,
-										"Get file handle: {:?} (attempt {})", bin_entry_path, attempt
-									);
 
-									FileHandle::new(&bin_entry_path)
-								},
-								Some(16),
-							)?;
-
-							file_handles_to_remove.push_back(file_handle);
+							if let Some(file_handle) = open_file_for_gc(log, &bin_entry_path)? {
+								file_handles_to_remove.push_back(file_handle);
+							}
 						} else {
 							info!(log, "Skipping non-old file in bin: {:?}", bin_entry_path);
 						}
@@ -989,21 +1004,9 @@ fn remove_files(
 			}
 		} else if entry_file_type.is_file() {
 			// Delete top-level files (except those already skipped)
-			let msg = format!("Opening file handle: {:?}", entry_path);
-			let file_handle = util::retry(
-				&msg,
-				|attempt| -> Result<FileHandle, Box<dyn error::Error>> {
-					info!(
-						log,
-						"Get file handle: {:?} (attempt {})", entry_path, attempt
-					);
-
-					FileHandle::new(&entry_path)
-				},
-				Some(16),
-			)?;
-
-			file_handles_to_remove.push_back(file_handle);
+			if let Some(file_handle) = open_file_for_gc(log, &entry_path)? {
+				file_handles_to_remove.push_back(file_handle);
+			}
 		}
 	}
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/307653 and https://github.com/microsoft/vscode/issues/299807